### PR TITLE
Fix #9 gl bench 1.default is not a constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ function draw(now) {
 renderer.setAnimationLoop((now) => draw(now));
 ```
 
+### Using TypeScript
+Replace ``import GLBench from 'gl-bench/dist/gl-bench';`` into ``import GLBench from 'gl-bench/dist/gl-bench.module';``
+
 ### Profiling with another WebGL frameworks
 ```javascript
 let gl = canvas.getContext('webgl') || canvas.getContext('experimental-webgl');

--- a/dist/gl-bench.module.d.ts
+++ b/dist/gl-bench.module.d.ts
@@ -1,0 +1,9 @@
+export default class GLBench {
+  constructor(gl: WebGLRenderingContext | WebGL2RenderingContext | null, settings?: object);
+
+  addUI(name?: string): void;
+
+  nextFrame(now?: number): void;
+  begin(name?: string): void;
+  end(name?: string): void;
+}


### PR DESCRIPTION
When I use TypeScript and follow the readme, I meet issue #9 , and I pr this to make it word find.